### PR TITLE
Get passed the data.table `real_cols` error

### DIFF
--- a/src/validate_historic_driver_data.R
+++ b/src/validate_historic_driver_data.R
@@ -36,7 +36,7 @@ validate_historic_driver_data <- function(var, fn, data_nc, hruids, time, time_f
   # Max of total storage in all of historic data for all HRUs is ~5,000 mm
   # Considering 300 mm is about 1 ft of water
   # An absolute max for order of magnitude check of 10,000 mm seems appropriate
-  #assert_that(max(data_nc) < 10000)
+  assert_that(max(data_nc) < 10000)
   
   # The validation step for order of magnitude for the daily model output has this step
   # but it will send an email (NOT FAIL) if this condition is not met. For the purposes

--- a/src/validate_historic_quantile_data.R
+++ b/src/validate_historic_quantile_data.R
@@ -21,21 +21,22 @@ validate_historic_quantile_data <- function(quantile_data, n_hrus = 114958, n_da
   
   ##### Test: HRUs with missing quantile data #####
   
-  # We know that one CA HRU doesn't have historic data for quantiles (104388) and will be Undefined
-  # This is also true for 7 other HRUs that are not in the U.S.
-  #problem_hruids <- c(104388, 46760, 46766, 46767, 82924, 82971, 82983, 82984)
+  # We used to have problem hruids that produced bad quantiles. With the Sep 2020 update,
+  # that no longer seems to be an issue. Leaving this functionality here in case
+  # some do come to light in the future. 
+  problem_hruids <- c() # HRUIDs with bad quantiles as numberic values
   real_cols <- percentile_cols[!percentile_cols %in% c("0%", "100%")]
-  #quantiles_problem_hru <- unlist(quantile_data[quantile_data$hruid %in% problem_hruids, real_cols], use.names=F)
-  #quantiles_good_hrus <- unlist(quantile_data[!quantile_data$hruid %in% problem_hruids, real_cols], use.names=F)
-  #assert_that(all(quantiles_problem_hru == 0)) # Every quantile will be 0 for these bad HRUs
-  #assert_that(any(quantiles_good_hrus > 0)) # There will be some that are greater than zero
+  quantiles_problem_hru <- unlist(quantile_data[quantile_data$hruid %in% problem_hruids, real_cols, with=FALSE], use.names=F)
+  quantiles_good_hrus <- unlist(quantile_data[!quantile_data$hruid %in% problem_hruids, real_cols, with=FALSE], use.names=F)
+  assert_that(all(quantiles_problem_hru == 0)) # Every quantile will be 0 for these bad HRUs
+  assert_that(any(quantiles_good_hrus > 0)) # There will be some that are greater than zero
   
   ##### Test: General order of magnitude #####
   
   # Max of total storage in all of historic total storage data for all HRUs is ~8,000 mm
   # Considering 300 mm is about 1 ft of water (diff between historic max and assumed max is ~ 6.5 ft of water)
   # An absolute max for order of magnitude check of 10,000 mm seems appropriate
-  just_quantile_data <- as.matrix(quantile_data[,real_cols])
+  just_quantile_data <- as.matrix(quantile_data[,real_cols, with=FALSE])
   assert_that(max(just_quantile_data) < 10000) 
   
 }


### PR DESCRIPTION
Apparently, data.table works slightly differently now. Fixed the issue that was causing it to not know how to use the vector `real_cols`. Also, reinstated the order of magnitude check. I see that you commented it out because it was failing, but that is intentional. We made an assumption that none of these variables would be > 10,000 mm because that would be 6.5 ft over the maximum historic value we had. We did this as an early gutcheck of the data's validity because last year we spent a lot of time working with data that was wayyy to large. Seems like this might be the case again. Might be an issue with units (I believe that is what is was last year).